### PR TITLE
feat(viewer-dym): LDAP domain (correspondant/mails) and display name in viewer

### DIFF
--- a/src/renderer/utils/constants.ts
+++ b/src/renderer/utils/constants.ts
@@ -45,7 +45,8 @@ export const MAX_TRESHOLD = 20;
 export const TRESHOLD_KEY = "_other";
 export const RATIO_FROM_MAX = 10;
 
-export const ORG_UNIT_PST = "/OU=";
+export const LDAP_ORG = "/O=";
+export const LDAP_ARBITRARY_SPLICE_CHAR = "O=";
 export const COMMON_NAME_PST = "/CN=";
 
 export const DOMAIN = "domain";

--- a/src/renderer/views/dashboard/DashboardInformationsMail.tsx
+++ b/src/renderer/views/dashboard/DashboardInformationsMail.tsx
@@ -22,7 +22,6 @@ export const DashboardInformationsMail: FC<{
                 {mainInfos.data.name}
             </div>
             <div>
-                {/* eslint-disable-next-line react/no-unescaped-entities */}
                 <strong>{t("dashboard.informations.sentDate")} </strong>{" "}
                 {sanitizeMailDate(mainInfos.data.email.sentTime!)}
             </div>


### PR DESCRIPTION
<!-- 🚨 Merci de respecter la convention semantic-pull-requests (https://github.com/zeke/semantic-pull-requests) principalement pour le titre de votre pull request. -->
<!-- Votre titre doit donc être de la forme : "feat:" ou "feat(xxx):", etc. -->

<!-- Lier le ticket associé (autocomplete à la place du "x" ou remplacer le "x" par l'id du ticket -->
Closes #110 

# Objectif(s)
Permettre de d'avoir un nom global provenant du domaine d'un LDAP (réuni sous le nom de l'organisation) puis d'afficher tous les correspondants/mails associés à ce LDAP. Enfin, permet l'affichage "propre" d'un contact au niveau de la visualisation mail. 
