### PR TITLE
feat(viewer): display other group domain

### DIFF
--- a/src/renderer/utils/dashboard-viewer-dym.ts
+++ b/src/renderer/utils/dashboard-viewer-dym.ts
@@ -14,7 +14,6 @@ import {
     LDAP_ORG,
     MAX_TRESHOLD,
     RATIO_FROM_MAX,
-    TRESHOLD_KEY,
 } from "./constants";
 
 interface BaseViewerObject<TId extends string> {
@@ -197,21 +196,23 @@ export const getAggregatedDomainCount = (
         );
     /* eslint-enable @typescript-eslint/naming-convention */
 
-    const threshold = getMailTreshold(mailCountPerDomain);
-    const thresholdify = (m: Map<string, number>): Map<string, number> => {
-        const out = new Map<string, number>();
-        for (const [k, v] of m) {
-            if (v < threshold) {
-                out.set(TRESHOLD_KEY, v + (out.get(TRESHOLD_KEY) ?? 0));
-            } else out.set(k, v);
-        }
+    // THRESHOLD LOGIC TO KEEP
+    //
+    // const threshold = getMailTreshold(mailCountPerDomain);
+    // const thresholdify = (m: Map<string, number>): Map<string, number> => {
+    //     const out = new Map<string, number>();
+    //     for (const [k, v] of m) {
+    //         if (v < threshold) {
+    //             out.set(TRESHOLD_KEY, v + (out.get(TRESHOLD_KEY) ?? 0));
+    //         } else out.set(k, v);
+    //     }
 
-        return out;
-    };
+    //     return out;
+    // };
 
-    const THERESULT = orderByValues(thresholdify(mailCountPerDomain));
+    // const THERESULT = orderByValues(thresholdify(mailCountPerDomain));
 
-    return toRecord(THERESULT);
+    return toRecord(orderByValues(mailCountPerDomain));
 };
 
 export const getUniqueCorrespondantsByDomain = (


### PR DESCRIPTION
<!-- 🚨 Merci de respecter la convention semantic-pull-requests (https://github.com/zeke/semantic-pull-requests) principalement pour le titre de votre pull request. -->
<!-- Votre titre doit donc être de la forme : "feat:" ou "feat(xxx):", etc. -->

<!-- Lier le ticket associé (autocomplete à la place du "x" ou remplacer le "x" par l'id du ticket -->
Closes #121 

# Objectif(s)
Afficher les domains précédemment ajoutés dans un groupe nommé `_other` car trop peu volumineux. 
